### PR TITLE
added feature for material list to ignore wrong states

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.2-SNAPSHOT'
+    id 'fabric-loom' version '1.4-SNAPSHOT'
     id 'com.modrinth.minotaur' version '2.+'
     id 'maven-publish'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx1G
 	# check these on https://modmuss50.me/fabric.html
 	minecraft_version=1.20.2
 	yarn_mappings=1.20.2+build.4
-	loader_version=0.14.24
+	loader_version=0.15.2
 
 # Mod Properties
 	mod_version = 1.2.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/earthcomputer/litemoretica/client/LitemoreticaConfigs.java
+++ b/src/main/java/net/earthcomputer/litemoretica/client/LitemoreticaConfigs.java
@@ -1,0 +1,17 @@
+package net.earthcomputer.litemoretica.client;
+
+import fi.dy.masa.malilib.config.IConfigBase;
+import fi.dy.masa.malilib.config.options.ConfigBoolean;
+
+public final class LitemoreticaConfigs {
+    private LitemoreticaConfigs() {
+    }
+
+    public static final ConfigBoolean MATERIAL_LIST_IGNORE_BLOCK_STATE = new ConfigBoolean("materialListIgnoreBlockState", true, "If true, ignores wrong blockstates\nwhen generating material lists");
+
+    public static IConfigBase[] getExtraGenericConfigs() {
+        return new IConfigBase[] {
+            MATERIAL_LIST_IGNORE_BLOCK_STATE,
+        };
+    }
+}

--- a/src/main/java/net/earthcomputer/litemoretica/mixin/client/ConfigsGenericMixin.java
+++ b/src/main/java/net/earthcomputer/litemoretica/mixin/client/ConfigsGenericMixin.java
@@ -1,0 +1,16 @@
+package net.earthcomputer.litemoretica.mixin.client;
+
+import fi.dy.masa.litematica.config.Configs;
+import net.earthcomputer.litemoretica.client.LitemoreticaConfigs;
+import org.apache.commons.lang3.ArrayUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(value = Configs.Generic.class, remap = false)
+public class ConfigsGenericMixin {
+    @ModifyArg(method = "<clinit>", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableList;of(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)Lcom/google/common/collect/ImmutableList;"))
+    private static Object[] modifyConfigs(Object[] configs) {
+        return ArrayUtils.addAll(configs, (Object[]) LitemoreticaConfigs.getExtraGenericConfigs());
+    }
+}

--- a/src/main/java/net/earthcomputer/litemoretica/mixin/client/TaskCountBlocksPlacementMixin_MaterialListFeature.java
+++ b/src/main/java/net/earthcomputer/litemoretica/mixin/client/TaskCountBlocksPlacementMixin_MaterialListFeature.java
@@ -1,0 +1,35 @@
+package net.earthcomputer.litemoretica.mixin.client;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import fi.dy.masa.litematica.materials.IMaterialList;
+import fi.dy.masa.litematica.scheduler.tasks.TaskCountBlocksBase;
+import fi.dy.masa.litematica.scheduler.tasks.TaskCountBlocksPlacement;
+import net.earthcomputer.litemoretica.client.LitemoreticaConfigs;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = TaskCountBlocksPlacement.class, remap = false)
+public abstract class TaskCountBlocksPlacementMixin_MaterialListFeature extends TaskCountBlocksBase {
+  @Unique private boolean ignoreState;
+
+  protected TaskCountBlocksPlacementMixin_MaterialListFeature(IMaterialList materialList, String nameOnHud) {
+    super(materialList, nameOnHud);
+  }
+
+  @Inject(method = "<init>", at = @At(value = "RETURN"))
+  private void onConstructor(CallbackInfo info) {
+    this.ignoreState = LitemoreticaConfigs.MATERIAL_LIST_IGNORE_BLOCK_STATE.getBooleanValue();
+  }
+
+  @Inject(method = "countAtPosition", at = @At(value = "FIELD", target = "Lfi/dy/masa/litematica/scheduler/tasks/TaskCountBlocksPlacement;countsMissing:Lit/unimi/dsi/fastutil/objects/Object2IntOpenHashMap;"), cancellable = true)
+  protected void countAtPosition(BlockPos pos, CallbackInfo ci, @Local(name = "stateSchematic") BlockState stateSchematic, @Local(name = "stateClient") BlockState stateClient) {
+      if (!stateClient.isAir() && ignoreState && stateClient.getBlock() == stateSchematic.getBlock()) {
+          ci.cancel();
+      }
+  }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,6 +26,7 @@
     "litemoretica.server.mixins.json"
   ],
   "depends": {
-    "minecraft": "${mcversions}"
+    "minecraft": "${mcversions}",
+    "fabricloader": ">=0.15.0"
   }
 }

--- a/src/main/resources/litemoretica.client.mixins.json
+++ b/src/main/resources/litemoretica.client.mixins.json
@@ -4,12 +4,14 @@
   "package": "net.earthcomputer.litemoretica.mixin.client",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "ConfigsGenericMixin",
     "HotkeysMixin",
     "PlacementHandlerAccessor",
     "PlacementHandlerMixin_EasyPlaceProtocol",
     "RayTraceUtilsMixin_ShapeContextFix",
     "SchematicPlacementManagerMixin_PasteHandler",
     "SchematicUtilsAccessor",
+    "TaskCountBlocksPlacementMixin_MaterialListFeature",
     "WorldUtilsAccessor",
     "WorldUtilsMixin_EasyPlaceFix"
   ],


### PR DESCRIPTION
We made this one together.

It adds a config in the `generic` tab (`materialListIgnoreBlockState`) to make generating material lists ignore wrong blockstates if the right block is present. It also defaults to being enabled because I think this should be the default behaviour of litematica.